### PR TITLE
Add Rrule iteration processing

### DIFF
--- a/.buildkite/docker-compose.yml
+++ b/.buildkite/docker-compose.yml
@@ -1,3 +1,4 @@
+version: '2.2'
 services:
   common:
     build:

--- a/.buildkite/docker-compose.yml
+++ b/.buildkite/docker-compose.yml
@@ -4,3 +4,7 @@ services:
     build:
       context: ../
       dockerfile: develop.Dockerfile
+
+  test:
+    extends: common
+    command: cargo test

--- a/.buildkite/docker-compose.yml
+++ b/.buildkite/docker-compose.yml
@@ -1,0 +1,5 @@
+services:
+  common:
+    build:
+      context: ../
+      dockerfile: develop.Dockerfile

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,6 @@
+steps:
+  - wait
+
+  - name: "Test"
+    artifact_paths: 'build/test-results'
+    command: ".buildkite/test.sh"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,3 +4,7 @@ steps:
   - name: "Test"
     artifact_paths: 'build/test-results'
     command: ".buildkite/test.sh"
+    plugins:
+      - github.com/buildkite-plugins/docker-compose-buildkite-plugin#b5922a5b0:
+          run: test
+          config: .buildkite/docker-compose.yml

--- a/.buildkite/test.sh
+++ b/.buildkite/test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+set -eu
+
+cargo test

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,13 @@
+Copyright [2019] [Ordermentum Pty Ltd]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+## Sundial 🚧
+
+Sundial is a library written in pure [Rust](https://www.rust-lang.org/) which partially implements the [iCalendar spec](https://tools.ietf.org/html/rfc5545) to support parsing of RRules.
+
+### Current high level features to be supported in this project
+
+- Abilitu to parse an RRule to a json representation
+
+- Ability to extract an RRule implementation from a given json
+
+- Ability to generate next iteration/iterations given an RRule string

--- a/develop.Dockerfile
+++ b/develop.Dockerfile
@@ -1,0 +1,6 @@
+FROM rust:1.31
+
+WORKDIR /usr/src/myapp
+COPY . .
+
+RUN cargo install --path .

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,7 +92,7 @@ impl<'a> RRule<'a> {
         if self.frequency.ne("SECONDLY") {
             let mut second: u32 = start_date.second();
             if !self.by_second.is_empty() {
-                second= self.by_second.first().unwrap().parse().unwrap();
+                second = self.by_second.first().unwrap().parse().unwrap();
             }
             start_date_with_intervals.with_second(second);
         }
@@ -107,7 +107,8 @@ impl<'a> RRule<'a> {
 
         if self.frequency.ne("SECONDLY")
             && self.frequency.ne("MONTHLY")
-            && self.frequency.ne("HOURLY") {
+            && self.frequency.ne("HOURLY")
+        {
             let mut hour: u32 = start_date.hour();
             if !self.by_hour.is_empty() {
                 hour = self.by_hour.first().unwrap().parse().unwrap();
@@ -135,17 +136,11 @@ impl<'a> RRule<'a> {
                 next_date = next_date.with_day(month_day).unwrap()
             } else if start_date_day > month_day {
                 if start_date.month().lt(&(12 as u32)) {
-                    let mut month_added = next_date
-                        .with_month(start_date.month() + 1)
-                        .unwrap();
+                    let mut month_added = next_date.with_month(start_date.month() + 1).unwrap();
                     next_date = month_added.with_day(month_day).unwrap();
                 } else {
-                    let mut year_added = next_date
-                        .with_year(start_date.year() + 1)
-                        .unwrap();
-                    let mut month_added = year_added
-                        .with_month(1)
-                        .unwrap();
+                    let mut year_added = next_date.with_year(start_date.year() + 1).unwrap();
+                    let mut month_added = year_added.with_month(1).unwrap();
                     next_date = month_added.with_day(month_day).unwrap();
                 }
             } else if start_date_day == month_day {
@@ -155,17 +150,11 @@ impl<'a> RRule<'a> {
                 // for next month
                 if start_date_with_intervals.ge(&start_date) {
                     if start_date.month().lt(&(12 as u32)) {
-                        let mut month_added = next_date
-                            .with_month(start_date.month() + 1)
-                            .unwrap();
+                        let mut month_added = next_date.with_month(start_date.month() + 1).unwrap();
                         next_date = month_added.with_day(month_day).unwrap();
                     } else {
-                        let mut year_added = next_date
-                            .with_year(start_date.year() + 1)
-                            .unwrap();
-                        let mut month_added = year_added
-                            .with_month(1)
-                            .unwrap();
+                        let mut year_added = next_date.with_year(start_date.year() + 1).unwrap();
+                        let mut month_added = year_added.with_month(1).unwrap();
                         next_date = month_added.with_day(month_day).unwrap();
                     }
                 }
@@ -301,9 +290,9 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use crate::{convert_to_rrule, RRule};
-    use serde_json::json;
-    use chrono::{Utc, Datelike};
     use chrono::offset::TimeZone;
+    use chrono::{Datelike, Utc};
+    use serde_json::json;
 
     struct RRuleTestCase<'a> {
         rrule_string: &'a str,
@@ -382,8 +371,14 @@ mod tests {
             by_year_day: Vec::new(),
         };
 
-        convert_to_rrule(&mut rrule_result, "FREQ=MONTHLY;INTERVAL=1;BYHOUR=9;BYMINUTE=1;BYMONTHDAY=28,27");
+        convert_to_rrule(
+            &mut rrule_result,
+            "FREQ=MONTHLY;INTERVAL=1;BYHOUR=9;BYMINUTE=1;BYMONTHDAY=28,27",
+        );
         let mut test_start_date = Utc.ymd(2019, 03, 15).and_hms(01, 12, 13);
-        assert_eq!(test_start_date.with_day(28).unwrap(), rrule_result.get_next_date(test_start_date))
+        assert_eq!(
+            test_start_date.with_day(28).unwrap(),
+            rrule_result.get_next_date(test_start_date)
+        )
     }
 }

--- a/src/rrule.pest
+++ b/src/rrule.pest
@@ -1,20 +1,23 @@
 rrule_expr = { SOI ~ expr | EOI }
 
 
-expr = { (freq_exprs ~ ((non_freq_exprs)+)?) | (((non_freq_exprs)+)? ~ freq_exprs) }
+expr = {  ((recur_exprs)+)? }
 
-freq_exprs = { ("FREQ=" ~ freq ~ ";") | ("FREQ=" ~ freq) }
-non_freq_exprs = _{ (non_freq_expr ~ ";") | non_freq_expr }
-non_freq_expr = _{ interval_expr |
-                    count_expr |
-                    byhour_expr |
-                    byminute_expr |
-                    bysecond_expr |
-                    byday_expr |
-                    bymonthday_expr |
-                    byyearday_expr }
+recur_exprs = _{ (recur_expr ~ ";") | recur_expr }
 
-freq = { secondly | minutely | hourly | daily | weekly | fortnightly | monthly | yearly }
+recur_expr = _{ freq_expr |
+                interval_expr |
+                count_expr |
+                byhour_expr |
+                byminute_expr |
+                bysecond_expr |
+                byday_expr |
+                bymonthday_expr |
+                byyearday_expr |
+                wkst_expr }
+
+freq_expr = { "FREQ=" ~ freq_field }
+freq_field = { secondly | minutely | hourly | daily | weekly | fortnightly | monthly | yearly }
     secondly = { "SECONDLY" }
     minutely = { "MINUTELY" }
     hourly = { "HOURLY" }
@@ -71,3 +74,6 @@ BYYEARDAY_DIGIT = { '1'..'9' | ('1'..'9' ~ '1'..'9') | // 1-99
                     ("3" ~ '1'..'6' ~ '1'..'6') }      // 300-366
 byyearday_field = @{ BYYEARDAY_DIGIT* ~ ("," ~ BYYEARDAY_DIGIT*)? }
 byyearday_expr = { "BYYEARDAY=" ~ byyearday_field }
+
+wkst_field = @{ weekday }
+wkst_expr = { "WKST=" ~ weekday }


### PR DESCRIPTION
### Description
Adds the initial ability to get next date iterations from an RRule string (currently only for monthly)

### Changes

- Given an RRule, we can now invoke the iterator to return all future dates for the rrule based on the count or defaults to 52. Function: `get_next_iter_dates()`

- Given an RRule and a start date, ability to calculate the next date matching the RRule expression (Currently only for monthlies)

- Fixed the issue where we had to do multiple acrobatics to parse the frequence Rrule expression

- Minor change to add `wkstart` as a supported Rrule param (only parsing for now) 