### PR TITLE
Only keep seconds on ISO8601 format

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1067,7 +1067,7 @@ fn lens_iter_dates(
 fn convert_datetime_tz_list_to_rfc339(dates_list: Vec<DateTime<Tz>>) -> Vec<String> {
     let mut converted_dates: Vec<String> = Vec::new();
     for date in dates_list.iter() {
-        converted_dates.push(date.to_rfc3339());
+        converted_dates.push(date.to_rfc3339_opts(SecondsFormat::Secs, false));
     }
     converted_dates
 }


### PR DESCRIPTION
### Description

Fix for the issue where when no dtstart is specified, using todays utc date causes us to include millis/micros and nanos in output.


### Changes
- Explicitly specify second format